### PR TITLE
Transformations after code block

### DIFF
--- a/typogr.js
+++ b/typogr.js
@@ -236,7 +236,7 @@
           // closing tag
           if ( skip_match[1] ) {
             if ( skipped_tag_stack.length > 0 ) {
-              if ( skipped_tag === skipped_tag_stack[-1] ) {
+              if ( skipped_tag === skipped_tag_stack[skipped_tag_stack.length-1] ) {
                 skipped_tag_stack.pop();
               }
             }


### PR DESCRIPTION
Transformations following code blocks currently aren't applied.

@lhagan has fixed the issue.
