### PR TITLE
Add global flag to caps() regex

### DIFF
--- a/typogr.js
+++ b/typogr.js
@@ -138,7 +138,7 @@
             '|(\\b[A-Z]+\\.\\s?'+  // OR: Group 3: Some caps, followed by a '.' and an optional space
             '(?:[A-Z]+\\.\\s?)+)'+ // Followed by the same thing at least once more
             '(?:\\s|\\b|$)'+
-          ')'
+          ')', 'g'
         );
 
       tokens.forEach( function (token) {


### PR DESCRIPTION
Currently, only the first caps of a string is being wrapped in a span.

This fixes the issue.
