### PR TITLE
Widont short headlines

### DIFF
--- a/test/typogr.test.js
+++ b/test/typogr.test.js
@@ -56,6 +56,7 @@ module.exports = {
     assert.equal(tp.widont('<h1>One Two</h1>'), '<h1>One Two</h1>')
     assert.equal(tp.widont('<h1>One Two Three</h1>'), '<h1>One Two Three</h1>')
     assert.equal(tp.widont('<h1>One  Two  Three</h1>'), '<h1>One  Two  Three</h1>')
+    assert.equal(tp.widont('<h1><a href="#">Links</a> should work</h1>'), '<h1><a href="#">Links</a> should work</h1>')
 
     assert.equal(tp.widont('<p>In a couple of paragraphs</p><p>the paragraph number two</p>'),
                            '<p>In a couple of&nbsp;paragraphs</p><p>the paragraph number&nbsp;two</p>');

--- a/typogr.js
+++ b/typogr.js
@@ -134,8 +134,13 @@
    *
    */
   var widont = typogr.widont = function(text) {
+    var inline_tags = 'a|em|span|strong|i|b'
+    var word = '(?:<(?:'+inline_tags+')[^>]*?>)*?[^\\s<>]+(?:</(?:'+inline_tags+')[^>]*?>)*?'
     var re_widont = re(
-          '(\\s+[^\\s]+\\s+[^\\s]+)'+                              // matching group 1: two words preceeded by space, need four words to trigger
+          '('+                                                     // matching group 1
+            '\\s+'+word+                                           // space and a word with a possible bordering tag
+            '\\s+'+word+                                           // space and a word with a possible bordering tag
+          ')'+
           '(?:\\s+)'+                                              // one or more space characters
           '('+                                                     // matching group 2
             '[^<>\\s]+'+                                           // nontag/nonspace characters


### PR DESCRIPTION
I had a problem with a two-word headline overflowing its containing box on a mobile layout, thanks to inadvertent use of widont and the non-breaking space it inserted. Thinking about it, in a case like this, four words is probably the minimum that should have its trailing words non-breaking, but I think there's room for discussion there.

This perhaps isn't the best solution, since I am short-circuiting the regexp, but it was easier to get something that worked and provided a better point for awareness of the problem.
