### PR TITLE
Use abbreviation element for small caps

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Also accounts for potential closing inline elements: `a`, `em`,
 caps
 ----
 
-Wraps multiple capital letters in `<span class="caps"></span>` so they can be styled.
+Wraps multiple capital letters in `<abbr class="caps"></abbr>` so they can be styled.
 
 ord
 ---

--- a/example/example.html
+++ b/example/example.html
@@ -19,7 +19,6 @@
           color:        #666;
           font-family:  "Alice";
           font-size:    150%;
-          font-style:   italic;
         }
         .dquo {
           font-family:  "Volkhov";

--- a/example/example.html
+++ b/example/example.html
@@ -13,7 +13,7 @@
       <meta name="author" content="Eugene Kalinin">
 
       <link rel="stylesheet" href="style.css">
-      <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Alice|Volkhov">
+      <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Fira+Sans|Alice|Volkhov&subset=latin,latin-ext">
       <style>
         .amp {
           color:        #666;
@@ -25,6 +25,13 @@
           font-family:  "Volkhov";
           margin-left:  -.5em;
           font-size:    1.5em;
+        }
+        .caps {
+          font-family: "Fira Sans";
+          text-transform: lowercase;
+          -webkit-font-feature-settings: "smcp", "c2sc", "pnum", "onum";
+             -moz-font-feature-settings: "smcp", "c2sc", "pnum", "onum";
+                  font-feature-settings: "smcp", "c2sc", "pnum", "onum";
         }
         footer {
           font-family:  "Alice";

--- a/test/qunit.test.html
+++ b/test/qunit.test.html
@@ -78,19 +78,19 @@
             });
             test('caps', function(){
               equal(tp.caps('A message from KU'),
-                   'A message from <span class="caps">KU</span>');
+                   'A message from <abbr class="caps">KU</abbr>');
               // Uses the smartypants tokenizer to not screw with HTML or with tags it shouldn't.
               equal(tp.caps('<PRE>CAPS</pre> more CAPS'),
-                   '<PRE>CAPS</pre> more <span class="caps">CAPS</span>');
+                   '<PRE>CAPS</pre> more <abbr class="caps">CAPS</abbr>');
               equal(tp.caps('A message from 2KU2 with digits'),
-                   'A message from <span class="caps">2KU2</span> with digits');
+                   'A message from <abbr class="caps">2KU2</abbr> with digits');
               equal(tp.caps('Dotted caps followed by spaces should never include them in the wrap D.O.T.   like so.'),
-                   'Dotted caps followed by spaces should never include them in the wrap <span class="caps">D.O.T.</span>  like so.');
+                   'Dotted caps followed by spaces should never include them in the wrap <abbr class="caps">D.O.T.</abbr>  like so.');
               // All caps with with apostrophes in them shouldn't break. Only handles dump apostrophes though.
               equal(tp.caps("JIMMY'S"),
-                   '<span class="caps">JIMMY\'S</span>');
+                   '<abbr class="caps">JIMMY\'S</abbr>');
               equal(tp.caps("<i>D.O.T.</i>HE34T<b>RFID</b>"),
-                   '<i><span class="caps">D.O.T.</span></i><span class="caps">HE34T</span><b><span class="caps">RFID</span></b>');
+                   '<i><abbr class="caps">D.O.T.</abbr></i><abbr class="caps">HE34T</abbr><b><abbr class="caps">RFID</abbr></b>');
             });
             test('tokenize', function(){
                 deepEqual( tp.tokenize('<h1>test header</h1>'+

--- a/test/test.cli.js
+++ b/test/test.cli.js
@@ -15,7 +15,7 @@ describe('./bin/typogr', function () {
   // variables used throughout the tests
 
   var testText = '<h2>"Jayhawks" & KU fans act extremely obnoxiously</h2>',
-    renderedText = '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <span class=\"caps\">KU</span> fans act extremely&nbsp;obnoxiously</h2>',
+    renderedText = '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <abbr class=\"caps\">KU</abbr> fans act extremely&nbsp;obnoxiously</h2>',
     testDir = '/var/tmp/typogr/',
     inputDir = testDir + 'input/',
     inputFiles = [ 'file1.html',

--- a/test/typogr.test.js
+++ b/test/typogr.test.js
@@ -83,19 +83,19 @@ module.exports = {
   },
   'caps tests': function(){
     assert.equal(tp.caps('A message from KU'),
-                'A message from <span class="caps">KU</span>');
+                'A message from <abbr class="caps">KU</abbr>');
     // Uses the smartypants tokenizer to not screw with HTML or with tags it shouldn't.
     assert.equal(tp.caps('<PRE>CAPS</pre> more CAPS'),
-                '<PRE>CAPS</pre> more <span class="caps">CAPS</span>');
+                '<PRE>CAPS</pre> more <abbr class="caps">CAPS</abbr>');
     assert.equal(tp.caps('A message from 2KU2 with digits'),
-                'A message from <span class="caps">2KU2</span> with digits');
+                'A message from <abbr class="caps">2KU2</abbr> with digits');
     assert.equal(tp.caps('Dotted caps followed by spaces should never include them in the wrap D.O.T.   like so.'),
-                'Dotted caps followed by spaces should never include them in the wrap <span class="caps">D.O.T.</span>  like so.');
+                'Dotted caps followed by spaces should never include them in the wrap <abbr class="caps">D.O.T.</abbr>  like so.');
     // All caps with with apostrophes in them shouldn't break. Only handles dump apostrophes though.
     assert.equal(tp.caps("JIMMY'S"),
-                '<span class="caps">JIMMY\'S</span>');
+                '<abbr class="caps">JIMMY\'S</abbr>');
     assert.equal(tp.caps("<i>D.O.T.</i>HE34T<b>RFID</b>"),
-                '<i><span class="caps">D.O.T.</span></i><span class="caps">HE34T</span><b><span class="caps">RFID</span></b>');
+                '<i><abbr class="caps">D.O.T.</abbr></i><abbr class="caps">HE34T</abbr><b><abbr class="caps">RFID</abbr></b>');
   },
   'tokenize': function(){
     assert.eql( tp.tokenize('<h1>test header</h1>'+
@@ -145,11 +145,11 @@ module.exports = {
   'typogrify': function(){
     assert.eql( tp.typogrify(
         '<h2>"Jayhawks" & KU fans act extremely obnoxiously</h2>'),
-        '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <span class=\"caps\">KU</span> fans act extremely&nbsp;obnoxiously</h2>');
+        '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <abbr class=\"caps\">KU</abbr> fans act extremely&nbsp;obnoxiously</h2>');
     assert.equal( tp('<h2>"Jayhawks" & KU fans act extremely obnoxiously</h2>').typogrify(),
-        '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <span class=\"caps\">KU</span> fans act extremely&nbsp;obnoxiously</h2>');
+        '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <abbr class=\"caps\">KU</abbr> fans act extremely&nbsp;obnoxiously</h2>');
     assert.equal( tp('<h2>"Jayhawks" & KU fans act extremely obnoxiously</h2>').chain().typogrify().value(),
-        '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <span class=\"caps\">KU</span> fans act extremely&nbsp;obnoxiously</h2>');
+        '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <abbr class=\"caps\">KU</abbr> fans act extremely&nbsp;obnoxiously</h2>');
     assert.eql( tp.typogrify({
           html: function () {
             return '<h2>"Jayhawks" & KU fans act extremely obnoxiously</h2>';
@@ -157,7 +157,7 @@ module.exports = {
           selector: '#some-test',
           jquery: '1.6.3-test'
         }),
-        '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <span class=\"caps\">KU</span> fans act extremely&nbsp;obnoxiously</h2>');
+        '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <abbr class=\"caps\">KU</abbr> fans act extremely&nbsp;obnoxiously</h2>');
     assert.doesNotThrow(function () {
       tp.typogrify("");
     });

--- a/typogr.js
+++ b/typogr.js
@@ -154,7 +154,7 @@
   };
 
   /**
-   * Wraps multiple capital letters in ``<span class="caps">``
+   * Wraps multiple capital letters in ``<abbr class="caps">``
    * so they can be styled with CSS.
    *
    */
@@ -196,7 +196,7 @@
               // This is necessary to keep dotted cap strings to pick up extra spaces
               var caps, tail;
               if ( g2 ) {
-                return '<span class="caps">%s</span>'.replace('%s', g2);
+                return '<abbr class="caps">%s</abbr>'.replace('%s', g2);
               } else {
                 if ( g3.slice(-1) === ' ' ) {
                   caps = g3.slice(0, -1);
@@ -205,7 +205,7 @@
                   caps = g3;
                   tail = '';
                 }
-                return '<span class="caps">%s1</span>%s2'.replace('%s1', caps).replace('%s2', tail);
+                return '<abbr class="caps">%s1</abbr>%s2'.replace('%s1', caps).replace('%s2', tail);
               }
             }));
           }


### PR DESCRIPTION
- Changes from `<span class="caps">` to `<abbr class="caps">`
- Updates tests accordingly
- Adds `font-feature-settings` and `.caps` example
