### PR TITLE
Added checks in case empty strings are passed, fixes #20

### DIFF
--- a/test/typogr.test.js
+++ b/test/typogr.test.js
@@ -155,5 +155,8 @@ module.exports = {
           jquery: '1.6.3-test'
         }),
         '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <span class=\"caps\">KU</span> fans act extremely&nbsp;obnoxiously</h2>');
+    assert.doesNotThrow(function () {
+      tp.typogrify("");
+    });
   },
 };

--- a/typogr.js
+++ b/typogr.js
@@ -43,7 +43,7 @@
                 //(    $1   )(     $2       )(   $3    )
       , re_intra_tag = /(<[^<]*>)?([^<]*)(<\/[^<]*>)?/g;
                       //( prefix) ( txt )(  suffix )
-    if( !text ) {
+    if( !text && typeof text !== "string" ) {
       return;
     }
     return text.replace(re_intra_tag, function (str, prefix, text, suffix) {
@@ -60,7 +60,7 @@
    *
    */
   var ord = typogr.ord = function(text) {
-    if( !text ) {
+    if( !text && typeof text !== "string" ) {
       return;
     }
 
@@ -115,7 +115,7 @@
              '(\'|&lsquo;|&#8216;))'                  // the left quotes and the primes/
           , 'i');
 
-    if( !text ) {
+    if( !text && typeof text !== "string" ) {
       return;
     }
     return text.replace(re_quote, function (matched_str, dquo, squo) {


### PR DESCRIPTION
initQuotes, amp and ord return if the text passed to them is a falsy
value - which makes the module crash if an empty string is passed.

An extra check fixes the problem.
