### PR TITLE
Don't wrap ampersands inside of the ignored tags.

### DIFF
--- a/test/typogr.test.js
+++ b/test/typogr.test.js
@@ -22,6 +22,9 @@ module.exports = {
     // It should ignore standalone amps that are in attributes
     assert.equal(tp.amp('<link href="xyz.html" title="One & Two">xyz</link>'),
                 '<link href="xyz.html" title="One & Two">xyz</link>');
+
+    // It should ignore amps inside script tags
+    assert.equal(tp.amp('<span><script>1 & 3 == 3</script></span>'), '<span><script>1 & 3 == 3</script></span>');
   },
   'ord tests': function(){
     assert.equal(tp.ord('1st'), '1<span class="ord">st</span>');

--- a/typogr.js
+++ b/typogr.js
@@ -49,6 +49,7 @@
     return text.replace(re_intra_tag, function (str, prefix, text, suffix) {
       prefix = prefix || '';
       suffix = suffix || '';
+      if (prefix.match(re_skip_tags)) return prefix + text + suffix;
       text = text.replace(re_amp, '$1<span class="amp">&amp;</span>$3');
 
       return prefix + text + suffix;


### PR DESCRIPTION
This will ignore an ampersand if it is inside of a tag matched by `/<(\/)?(pre|code|kbd|script|math|title)[^>]*>/i`. Previously, ampersands inside of script tags would be wrapped. This also adds a test.
