### PR TITLE
Adds wrapper around Widon’t breaking space

### DIFF
--- a/test/qunit.test.html
+++ b/test/qunit.test.html
@@ -49,32 +49,32 @@
                                        '<h2> <span class="dquo">&#8220;</span>Jayhawks&#8221; & KU fans ... </h2>');
             });
             test('widont', function(){
-                equal(tp.widont('A very simple test'), 'A very simple&nbsp;test');
+                equal(tp.widont('A very simple test'), 'A very simple<span class="widont">&nbsp;</span>test');
                 // Single word items shouldn't be changed
                 equal(tp.widont('Test'), 'Test');
                 equal(tp.widont(' Test'), ' Test');
                 equal(tp.widont('<ul><li>Test</p></li><ul>'), '<ul><li>Test</p></li><ul>');
                 equal(tp.widont('<ul><li> Test</p></li><ul>'), '<ul><li> Test</p></li><ul>');
                 equal(tp.widont('<p>In a couple of paragraphs</p><p>paragraph two</p>'),
-                                '<p>In a couple of&nbsp;paragraphs</p><p>paragraph&nbsp;two</p>');
+                                '<p>In a couple of<span class="widont">&nbsp;</span>paragraphs</p><p>paragraph<span class="widont">&nbsp;</span>two</p>');
                 equal(tp.widont('<h1><a href="#">In a link inside a heading</i> </a></h1>'),
-                                '<h1><a href="#">In a link inside a&nbsp;heading</i> </a></h1>');
+                                '<h1><a href="#">In a link inside a<span class="widont">&nbsp;</span>heading</i> </a></h1>');
                 equal(tp.widont('<h1><a href="#">In a link</a> followed by other text</h1>'),
-                                       '<h1><a href="#">In a link</a> followed by other&nbsp;text</h1>');
+                                       '<h1><a href="#">In a link</a> followed by other<span class="widont">&nbsp;</span>text</h1>');
                 // Empty HTMLs shouldn't error
                 equal(tp.widont('<h1><a href="#"></a></h1>'), '<h1><a href="#"></a></h1>');
                 equal(tp.widont('<div>Divs get no love!</div>'), '<div>Divs get no love!</div>');
                 equal(tp.widont('<pre>Neither do PREs</pre>'), '<pre>Neither do PREs</pre>');
                 equal(tp.widont('<div><p>But divs with paragraphs do!</p></div>'),
-                                       '<div><p>But divs with paragraphs&nbsp;do!</p></div>');
+                                       '<div><p>But divs with paragraphs<span class="widont">&nbsp;</span>do!</p></div>');
                 // It should ignore inline tags
                 equal(tp.widont('<p>Testing with a tag at <strong>the end</strong>.</p>'),
-                                       '<p>Testing with a tag at <strong>the&nbsp;end</strong>.</p>');
+                                       '<p>Testing with a tag at <strong>the<span class="widont">&nbsp;</span>end</strong>.</p>');
                 equal(tp.widont('<p>Testing with <strong>multiple inline</strong> tags at <a href="#"><strong><em>the end</em></strong></a>.</p>'),
-                                       '<p>Testing with <strong>multiple inline</strong> tags at <a href="#"><strong><em>the&nbsp;end</em></strong></a>.</p>');
+                                       '<p>Testing with <strong>multiple inline</strong> tags at <a href="#"><strong><em>the<span class="widont">&nbsp;</span>end</em></strong></a>.</p>');
                 // It should also take commas into consideration
                 equal(tp.widont('<p>Start of the paragraph ... before they get deleted-I mean, published.</p>'),
-                                        '<p>Start of the paragraph ... before they get deleted-I mean,&nbsp;published.</p>');
+                                        '<p>Start of the paragraph ... before they get deleted-I mean,<span class="widont">&nbsp;</span>published.</p>');
             });
             test('caps', function(){
               equal(tp.caps('A message from KU'),
@@ -141,11 +141,11 @@
             test('typogrify', function(){
                 equal( tp.typogrify(
                     '<h2>"Jayhawks" & KU fans act extremely obnoxiously</h2>'),
-                    '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <span class=\"caps\">KU</span> fans act extremely&nbsp;obnoxiously</h2>');
+                    '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <span class=\"caps\">KU</span> fans act extremely<span class="widont">&nbsp;</span>obnoxiously</h2>');
                 equal( tp('<h2>"Jayhawks" & KU fans act extremely obnoxiously</h2>').typogrify(),
-                    '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <span class=\"caps\">KU</span> fans act extremely&nbsp;obnoxiously</h2>');
+                    '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <span class=\"caps\">KU</span> fans act extremely<span class="widont">&nbsp;</span>obnoxiously</h2>');
                 equal( tp('<h2>"Jayhawks" & KU fans act extremely obnoxiously</h2>').chain().typogrify().value(),
-                    '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <span class=\"caps\">KU</span> fans act extremely&nbsp;obnoxiously</h2>');
+                    '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <span class=\"caps\">KU</span> fans act extremely<span class="widont">&nbsp;</span>obnoxiously</h2>');
             });
         });
     </script>

--- a/test/test.cli.js
+++ b/test/test.cli.js
@@ -15,7 +15,7 @@ describe('./bin/typogr', function () {
   // variables used throughout the tests
 
   var testText = '<h2>"Jayhawks" & KU fans act extremely obnoxiously</h2>',
-    renderedText = '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <span class=\"caps\">KU</span> fans act extremely&nbsp;obnoxiously</h2>',
+    renderedText = '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <span class=\"caps\">KU</span> fans act extremely<span class="widont">&nbsp;</span>obnoxiously</h2>',
     testDir = '/var/tmp/typogr/',
     inputDir = testDir + 'input/',
     inputFiles = [ 'file1.html',

--- a/test/typogr.test.js
+++ b/test/typogr.test.js
@@ -49,7 +49,7 @@ module.exports = {
                            '<h2> <span class="dquo">&#8220;</span>Jayhawks&#8221; & KU fans ... </h2>');
   },
   'widont tests': function(){
-    assert.equal(tp.widont('A very simple test'), 'A very simple&nbsp;test');
+    assert.equal(tp.widont('A very simple test'), 'A very simple<span class="widont">&nbsp;</span>test');
     // Single word items shouldn't be changed
     assert.equal(tp.widont('Test'), 'Test');
     assert.equal(tp.widont(' Test'), ' Test');
@@ -62,23 +62,23 @@ module.exports = {
     assert.equal(tp.widont('<h1><a href="#">Links</a> should work</h1>'), '<h1><a href="#">Links</a> should work</h1>')
 
     assert.equal(tp.widont('<p>In a couple of paragraphs</p><p>the paragraph number two</p>'),
-                           '<p>In a couple of&nbsp;paragraphs</p><p>the paragraph number&nbsp;two</p>');
+                           '<p>In a couple of<span class="widont">&nbsp;</span>paragraphs</p><p>the paragraph number<span class="widont">&nbsp;</span>two</p>');
     assert.equal(tp.widont('<h1><a href="#">In a link inside a heading</i> </a></h1>'),
-                           '<h1><a href="#">In a link inside a&nbsp;heading</i> </a></h1>');
+                           '<h1><a href="#">In a link inside a<span class="widont">&nbsp;</span>heading</i> </a></h1>');
     assert.equal(tp.widont('<h1><a href="#">In a link</a> followed by other text</h1>'),
-                           '<h1><a href="#">In a link</a> followed by other&nbsp;text</h1>');
+                           '<h1><a href="#">In a link</a> followed by other<span class="widont">&nbsp;</span>text</h1>');
     // Empty HTMLs shouldn't error
     assert.equal(tp.widont('<h1><a href="#"></a></h1>'), '<h1><a href="#"></a></h1>');
     assert.equal(tp.widont('<div>Divs get no love!</div>'), '<div>Divs get no love!</div>');
     assert.equal(tp.widont('<pre>Neither do PREs</pre>'), '<pre>Neither do PREs</pre>');
     assert.equal(tp.widont('<div><p>But divs with paragraphs do!</p></div>'),
-                           '<div><p>But divs with paragraphs&nbsp;do!</p></div>');
+                           '<div><p>But divs with paragraphs<span class="widont">&nbsp;</span>do!</p></div>');
     // It should ignore inline tags
-    assert.equal(tp.widont('<p>Testing with a tag at <strong>the end</strong>.</p>'), '<p>Testing with a tag at <strong>the&nbsp;end</strong>.</p>');
-    assert.equal(tp.widont('<p>Testing with <strong>multiple inline</strong> tags at <a href="#"><strong><em>the end</em></strong></a>.</p>'), '<p>Testing with <strong>multiple inline</strong> tags at <a href="#"><strong><em>the&nbsp;end</em></strong></a>.</p>');
+    assert.equal(tp.widont('<p>Testing with a tag at <strong>the end</strong>.</p>'), '<p>Testing with a tag at <strong>the<span class="widont">&nbsp;</span>end</strong>.</p>');
+    assert.equal(tp.widont('<p>Testing with <strong>multiple inline</strong> tags at <a href="#"><strong><em>the end</em></strong></a>.</p>'), '<p>Testing with <strong>multiple inline</strong> tags at <a href="#"><strong><em>the<span class="widont">&nbsp;</span>end</em></strong></a>.</p>');
     // It should also take commas into consideration
     assert.equal(tp.widont('<p>Start of the paragraph ... before they get deleted-I mean, published.</p>'),
-                    '<p>Start of the paragraph ... before they get deleted-I mean,&nbsp;published.</p>');
+                    '<p>Start of the paragraph ... before they get deleted-I mean,<span class="widont">&nbsp;</span>published.</p>');
 
   },
   'caps tests': function(){
@@ -145,11 +145,11 @@ module.exports = {
   'typogrify': function(){
     assert.eql( tp.typogrify(
         '<h2>"Jayhawks" & KU fans act extremely obnoxiously</h2>'),
-        '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <span class=\"caps\">KU</span> fans act extremely&nbsp;obnoxiously</h2>');
+        '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <span class=\"caps\">KU</span> fans act extremely<span class="widont">&nbsp;</span>obnoxiously</h2>');
     assert.equal( tp('<h2>"Jayhawks" & KU fans act extremely obnoxiously</h2>').typogrify(),
-        '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <span class=\"caps\">KU</span> fans act extremely&nbsp;obnoxiously</h2>');
+        '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <span class=\"caps\">KU</span> fans act extremely<span class="widont">&nbsp;</span>obnoxiously</h2>');
     assert.equal( tp('<h2>"Jayhawks" & KU fans act extremely obnoxiously</h2>').chain().typogrify().value(),
-        '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <span class=\"caps\">KU</span> fans act extremely&nbsp;obnoxiously</h2>');
+        '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <span class=\"caps\">KU</span> fans act extremely<span class="widont">&nbsp;</span>obnoxiously</h2>');
     assert.eql( tp.typogrify({
           html: function () {
             return '<h2>"Jayhawks" & KU fans act extremely obnoxiously</h2>';
@@ -157,7 +157,7 @@ module.exports = {
           selector: '#some-test',
           jquery: '1.6.3-test'
         }),
-        '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <span class=\"caps\">KU</span> fans act extremely&nbsp;obnoxiously</h2>');
+        '<h2><span class="dquo">&#8220;</span>Jayhawks&#8221; <span class="amp">&amp;</span> <span class=\"caps\">KU</span> fans act extremely<span class="widont">&nbsp;</span>obnoxiously</h2>');
     assert.doesNotThrow(function () {
       tp.typogrify("");
     });

--- a/typogr.js
+++ b/typogr.js
@@ -150,7 +150,7 @@
                                                                    // and followed by a period.
             '(?:\\s*?</(?:p|h[1-6]|li|dt|dd)>|$)'+                 // allowed closing tags or end of line
           ')', 'gi');
-    return text.replace(re_widont, '$1&nbsp;$2');
+    return text.replace(re_widont, '$1<span class="widont">&nbsp;</span>$2');
   };
 
   /**


### PR DESCRIPTION
This pull request adds a `span` around the `&nbsp;` generated for stopping trailing words, similar to the `.ord` and `.amp` classes. This allows you to use the breaking space differently depending on the media query, for example:

```css
.widont {
  display: inline-block; /* Ignore the breaking space */
  outline: 1px solid blue;
}

@media (min-width: 35em) {
  display: inline; /* Restore the breaking space at larger screen sizes */
  outline: 1px solid purple;
}
```

This works really well for mobile first styling, where you only opt-into the feature at larger breakpoints. I don’t think individual trailing words were ever seen as a thing to be avoided 100% of the time—something you’ve already accounted for really well by scoping it to certain elements. This just goes one step further and allows you to decide whether or not widows should be avoided depending on the current line length or break point.

<img src="https://cloud.githubusercontent.com/assets/1581276/8274675/8c4b8cfc-184a-11e5-852e-b62e20f33fc0.png" alt="" width="50%">

<img src="https://cloud.githubusercontent.com/assets/1581276/8274674/8a851744-184a-11e5-8ebe-fc01e0deb3c8.png" alt="">

