### PR TITLE
typogr/smartypants needs to skip style-tags

### DIFF
--- a/typogr.js
+++ b/typogr.js
@@ -30,7 +30,7 @@
   };
 
   // RegExp for skip some tags
-  var re_skip_tags = /<(\/)?(pre|code|kbd|script|math|title)[^>]*>/i;
+  var re_skip_tags = /<(\/)?(style|pre|code|kbd|script|math|title)[^>]*>/i;
 
   /**
    * Wraps apersands in HTML with ``<span class="amp">`` so they can be


### PR DESCRIPTION
For example `<style>body { font-family: "Open Sans"; }...` becomes `<style>body { font-family: &#8221;Open Sans&#8221; }...` which is invalid CSS.