### PR TITLE
Don't change the double dash in HTML comments to an en dash

### DIFF
--- a/test/typogr.test.js
+++ b/test/typogr.test.js
@@ -122,7 +122,7 @@ module.exports = {
     assert.eql( tp.smartDashes( '-- : --- : -- : ---'),
                   '&#8211; : &#8212; : &#8211; : &#8212;');
     assert.eql( tp.smartDashes( '<!--:-->:<!-- valid html comment -->'),
-                  '<!--:-->:<!-- valid html comment -->:');
+                  '<!--:-->:<!-- valid html comment -->');
 
   },
   'smartEllipses': function(){

--- a/typogr.js
+++ b/typogr.js
@@ -380,7 +380,7 @@
    */
   var smartDashes = typogr.smartDashes = function(text) {
     return text.replace(/---/g, '&#8212;')    // em  (yes, backwards)
-               .replace(/--/g,  '&#8211;');   // en  (yes, backwards)
+               .replace(/([^<][^!]|[^!]|^)--(?!>)/g,  '$1&#8211;');  // en  (yes, backwards)
   };
 
   /**


### PR DESCRIPTION
This is my solution to #27. The regex is nasty because JavaScript doesn't support negative lookbehinds, but it (seems) to work.

Thanks!