### PR TITLE
Enable Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+- "stable"
+install:
+- npm install
+sudo: false

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     }
   ],
   "scripts": {
-    "test": "./node_modules/.bin/expresso test/typogr.test.js; ./node_modules/.bin/mocha test/test.cli.js"
+    "test": "./node_modules/.bin/expresso test/typogr.test.js && ./node_modules/.bin/mocha test/test.cli.js"
   },
   "bin": {
     "typogr": "./bin/typogr"


### PR DESCRIPTION
[Travis CI](https://travis-ci.org) will run tests automatically and add information about the tests on their pull requests. This is nice because it allows everyone to see whether the tests pass for a PR without running them manually.

To enable Travis, you'll have to go to the website, connect your GitHub account, and enable the typogr.js repo.