### PR TITLE
Suggest simple browser usage use RawGit's CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Simple in the browser
 
 ```html
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script>
-<script src="https://raw.github.com/ekalinin/typogr.js/master/typogr.min.js"></script>
+<script src="https://cdn.rawgit.com/ekalinin/typogr.js/0.6.6/typogr.min.js"></script>
 <script>
 $(document).ready(function() {
     $('#res').html(typogr.typogrify($('#src')));


### PR DESCRIPTION
GitHub's raw user content does not provide the right MIME types, whereas RawGit does.