### PR TITLE
 #39 rock and roll aware

### DIFF
--- a/test/typogr.test.js
+++ b/test/typogr.test.js
@@ -144,6 +144,8 @@ module.exports = {
                            '&#8220;<a href="http://example.com">switched off</a>&#8221;.');
     assert.eql( tp.smartypants('<a href="">markdown</a>\'s popularity is growing'),
                            '<a href="">markdown</a>&#8217;s popularity is growing');
+    assert.eql( tp.smartypants("<p>I love rock 'n' roll</p>"),
+                           '<p>I love rock &#8217;n&#8217; roll</p>');
   },
   'typogrify': function(){
     assert.eql( tp.typogrify(

--- a/typogr.js
+++ b/typogr.js
@@ -286,6 +286,10 @@
         }
       } else {
         t = token.txt;
+
+        // Special case rock ’n’ roll—use apostrophes
+        t = t.replace(/(rock )'n'( roll)/gi, '$1&#8217;n&#8217;$2');
+
         // Remember last char of this token before processing
         last_char = t.slice(-1);
 


### PR DESCRIPTION
Fix #39 

Use two apostrophes for the 'n' in rock ’n’ roll.

![rock 'n' roll punctuation](http://www.paperspecs.com/wp-content/uploads/2012/05/C.Smart-quotes.jpg)