### PR TITLE
Updates glob to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "typogr": "./bin/typogr"
   },
   "dependencies": {
-    "commander": "1.0",
     "async": "0.2",
-    "glob": "3",
+    "commander": "1.0",
+    "glob": "^7.1.2",
     "mkdirp": "0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #38. Typogr.js is showing up as with a high priority warning with `npm audit` now, even if you are using Typogr.js as a client side dependency, where glob isn’t used. This PR bumps the dependency to the latest version, and adds a `^` for the future. All tests are still passing on Node v4, v6, and v8.